### PR TITLE
thermalmanager qdbus interface doesn't work with invalid arguments

### DIFF
--- a/src/devicestate/ipcinterface.cpp
+++ b/src/devicestate/ipcinterface.cpp
@@ -58,7 +58,15 @@ QList<QVariant> IPCInterface::get(const QString& method,
                                     const QVariant& arg1,
                                     const QVariant& arg2) {
     QList<QVariant> results;
-    QDBusMessage msg = call(method, arg1, arg2);
+
+    QDBusMessage msg;
+    if (arg1.isValid() && arg2.isValid()) {
+        msg = call(method, arg1, arg2);
+    } else if (arg1.isValid()) {
+        msg = call(method, arg1);
+    } else {
+        msg = call(method);
+    }
     if (msg.type() == QDBusMessage::ReplyMessage) {
         results  = msg.arguments();
     }


### PR DESCRIPTION
This error message doesn't show after change:

QDBusMarshaller: cannot add an invalid QVariant
QDBusMarshaller: cannot add an invalid QVariant
QDBusConnection: error: could not send message to service com.nokia.thermalmanager path /com/nokia/thermalmanager interface com.nokia.thermalmanager member get_thermal_state: Marshalling failed: Variant containing QVariant::Invalid passed in arguments