### PR TITLE
fix(cmake): link to the built CMake target rather than manually specifying the link target

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -38,7 +38,10 @@ target_link_libraries(${PACKAGE} PUBLIC
     PkgConfig::WAYLAND_SERVER
     PkgConfig::USB_MODED_QT
     KF6::BluezQt
-    -lrt -lEGL -L../src -llipstick-qt6)
+    lipstick-qt6
+    -lrt
+    -lEGL
+)
 
 install(TARGETS ${PACKAGE} LIBRARY DESTINATION "${QT_INSTALL_QML}/org/nemomobile/lipstick")
 

--- a/tests/ut_closeeventeater/CMakeLists.txt
+++ b/tests/ut_closeeventeater/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(ut_${TESTNAME}
     PkgConfig::DBUS
     PkgConfig::MLITE
     PkgConfig::SYSTEMSETTINGS
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_launchermodel/CMakeLists.txt
+++ b/tests/ut_launchermodel/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(ut_${TESTNAME} PUBLIC
     PkgConfig::GIO_UNIX
     PkgConfig::MLITE
     PkgConfig::SYSTEMSETTINGS
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_lipsticknotification/CMakeLists.txt
+++ b/tests/ut_lipsticknotification/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(ut_${TESTNAME}
     Qt6::WaylandCompositor
     Qt6::Test
     PkgConfig::DBUS
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_lipsticksettings/CMakeLists.txt
+++ b/tests/ut_lipsticksettings/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(ut_${TESTNAME}
     PkgConfig::DBUS
     PkgConfig::MLITE
     PkgConfig::SYSTEMSETTINGS
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_notificationfeedbackplayer/CMakeLists.txt
+++ b/tests/ut_notificationfeedbackplayer/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(ut_${TESTNAME}
     PkgConfig::SYSTEMSETTINGS
     PkgConfig::NGF_QT6
     PkgConfig::TIMED_QT
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_notificationlistmodel/CMakeLists.txt
+++ b/tests/ut_notificationlistmodel/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(ut_${TESTNAME}
     PkgConfig::DBUS
     PkgConfig::MLITE
     PkgConfig::SYSTEMSETTINGS
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_notificationmanager/CMakeLists.txt
+++ b/tests/ut_notificationmanager/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(ut_${TESTNAME}
     PkgConfig::DBUS
     PkgConfig::MLITE
     PkgConfig::SYSTEMSETTINGS
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_notificationpreviewpresenter/CMakeLists.txt
+++ b/tests/ut_notificationpreviewpresenter/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(ut_${TESTNAME}
     PkgConfig::NEMODEVICELOCK
     PkgConfig::SYSTEMSETTINGS
     PkgConfig::TIMED_QT
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_qobjectlistmodel/CMakeLists.txt
+++ b/tests/ut_qobjectlistmodel/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(ut_${TESTNAME}
     Qt6::Core
     Qt6::Quick
     Qt6::Test
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_screenlock/CMakeLists.txt
+++ b/tests/ut_screenlock/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(ut_${TESTNAME}
     Qt6::Quick
     Qt6::DBus
     Qt6::Test
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_shutdownscreen/CMakeLists.txt
+++ b/tests/ut_shutdownscreen/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(ut_${TESTNAME}
     PkgConfig::MLITE
     PkgConfig::TIMED_QT
     PkgConfig::THERMALMANAGER_DBUS
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_touchscreen/CMakeLists.txt
+++ b/tests/ut_touchscreen/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(ut_${TESTNAME}
     PkgConfig::LIBRESOURCE
     PkgConfig::NEMODEVICELOCK
     PkgConfig::USB_MODED_QT
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_usbmodeselector/CMakeLists.txt
+++ b/tests/ut_usbmodeselector/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(ut_${TESTNAME}
     PkgConfig::TIMED_QT
     PkgConfig::USB_MODED
     PkgConfig::USB_MODED_QT
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})

--- a/tests/ut_volumecontrol/CMakeLists.txt
+++ b/tests/ut_volumecontrol/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(ut_${TESTNAME}
     PkgConfig::GLIB2
     PkgConfig::LIBRESOURCE
     PkgConfig::TIMED_QT
-    -llipstick-qt6 -L../../src)
+    lipstick-qt6
+)
 
 add_test(ut_${TESTNAME} ut_${TESTNAME})


### PR DESCRIPTION
On my system it wasn't -llipstick-qt6 and although I'm not sure what else it would be, there is no need to specify such a target manually when we can just link to the known CMake target instead and let CMake figure it out itself.